### PR TITLE
js: Throw an error instead of trying to load a module with no file

### DIFF
--- a/runtime/js/bootstrapper.js
+++ b/runtime/js/bootstrapper.js
@@ -81,6 +81,9 @@ let Bootstrapper = class {
 	loadModuleFromFile(filename, sendJustLoaded = true)
 	{
 		const filepath = this.findInPath(filename);
+		if (filepath === undefined) {
+			throw new Error(`Failed to load ${filename}`);
+		}
 		const reader = new ImageSegmentReader();
 		reader.loadFile(filepath);
 		this.bindModuleImports(reader);


### PR DESCRIPTION
When an image segment is not present the current implementation fails at a point where the error message doesn't make sense. I'm not sure if this is the correct approach, but something similar to this should be done.