### PR TITLE
js: Add missing method to PowertalkLMR (sent from EvaluationContext)

### DIFF
--- a/bootstrap/pharo/Powerlang-Core/PowertalkLMR.class.st
+++ b/bootstrap/pharo/Powerlang-Core/PowertalkLMR.class.st
@@ -908,6 +908,11 @@ PowertalkLMR >> staticBindingForIvar: aSymbol in: receiver [
 ]
 
 { #category : #initialization }
+PowertalkLMR >> storeAssociation: association value: anObject [
+	association slotAt: 2 put: anObject
+]
+
+{ #category : #initialization }
 PowertalkLMR >> stringClass: anLMRObject [
 	stringClass := anLMRObject
 ]


### PR DESCRIPTION
The #storeAssociation:value: message is sent by `EvaluationContext` and implemented on `PowertalkRingRuntime`.

This PR adds it to `PowertalkLMR` too.