### PR TITLE
bootstrap: Fix error when building and using the constant literals of compiled methods

### DIFF
--- a/bootstrap/pharo/Powerlang-SCompiler/AstcodeEncoder.class.st
+++ b/bootstrap/pharo/Powerlang-SCompiler/AstcodeEncoder.class.st
@@ -133,6 +133,14 @@ AstcodeEncoder >> encodedEnvironment: aLocalEnvironment [
 ]
 
 { #category : #accessing }
+AstcodeEncoder >> findLiteralIndex: anObject ifAbsent: aBlock [
+	^ method
+		detectIndex: [ :v |
+			v = anObject and: v class = anObject class ]
+		ifNone: aBlock
+]
+
+{ #category : #accessing }
 AstcodeEncoder >> initialize [
 	stream := #[] writeStream
 ]
@@ -169,8 +177,8 @@ AstcodeEncoder >> nextIntegerPut: anInteger [
 { #category : #visiting }
 AstcodeEncoder >> nextLiteralPut: anObject [
 	| index |
-	index := method
-		indexOf: anObject
+	index := self
+		findLiteralIndex: anObject
 		ifAbsent: [ self ASSERT: false ].
 	self nextIntegerPut: index
 ]
@@ -188,8 +196,8 @@ AstcodeEncoder >> nextPutAll: aCollection [
 { #category : #visiting }
 AstcodeEncoder >> nextSymbolPut: aSymbol [
 	| index |
-	index := method
-		indexOf: aSymbol asSymbol
+	index := self
+		findLiteralIndex: aSymbol asSymbol
 		ifAbsent: [ self ASSERT: false ].
 	self nextIntegerPut: index
 ]
@@ -261,7 +269,9 @@ AstcodeEncoder >> visitIdentifier: anIdentifierNode [
 { #category : #visiting }
 AstcodeEncoder >> visitLiteral: aLiteralNode [
 	| index |
-	index := method indexOf: aLiteralNode value.
+	index := self
+		findLiteralIndex: aLiteralNode value
+		ifAbsent: [ 0 ].
 	self
 		nextTypePut: LiteralId;
 		nextIntegerPut: index.

--- a/bootstrap/pharo/Powerlang-SCompiler/SMethodNode.class.st
+++ b/bootstrap/pharo/Powerlang-SCompiler/SMethodNode.class.st
@@ -76,7 +76,7 @@ SMethodNode >> isMethod [
 
 { #category : #parsing }
 SMethodNode >> literals [
-	| literals v l |
+	| literals v l literalsWithClasses |
 	literals := OrderedCollection new.
 	pragma isUsed
 		ifTrue: [ literals add: pragma name ].
@@ -102,7 +102,10 @@ SMethodNode >> literals [
 				ifTrue: [ literals add: l ].
 			(n isBlockNode andNot: [ n isInlined ])
 				ifTrue: [ literals add: n buildBlock ] ].
-	^ literals removeDuplicates
+	"Pharo thinks symbols and strings are the same. We disagree"
+	literalsWithClasses := literals collect: [ :n | n -> n class ].
+	literalsWithClasses removeDuplicates.
+	^ literalsWithClasses collect: [ :n | n key ].
 ]
 
 { #category : #parsing }


### PR DESCRIPTION
The current implementation has an issue where `#text` is confused with `'text'` resulting in the interpreter being unable to find the `'text`` variable or sending the `'test'` message.

An alternative implementation is to never store strings on constant pools and just use symbols always.