### PR TITLE
bootstrap: Keep categories when loading modules

### DIFF
--- a/bootstrap/pharo/Powerlang-Core/PowertalkRingModule.class.st
+++ b/bootstrap/pharo/Powerlang-Core/PowertalkRingModule.class.st
@@ -204,7 +204,7 @@ PowertalkRingModule >> fillClasses [
 { #category : #initialization }
 PowertalkRingModule >> fillSpecies: species with: classDefinition [
 
-	| dictionary smethod transferred tags organization category |
+	| dictionary smethod transferred organization category |
 	dictionary := self
 		              createMethodDictionary: species
 		              sized: classDefinition methods size.
@@ -214,11 +214,12 @@ PowertalkRingModule >> fillSpecies: species with: classDefinition [
 		runtime sendLocal: #basicAt:put: to: dictionary with: { 
 				transferred selector.
 				transferred }.
-		tags := methodDefinition tags.
-		tags notEmpty ifTrue: [ 
+
 		organization := runtime sendLocal: #organization to: species.
-		category := runtime newSymbol: tags anyone.
-		runtime sendLocal: #classify:under: to: organization with: { transferred selector. category } ]]
+		category := runtime newSymbol: methodDefinition category.
+		runtime sendLocal: #classify:under: to: organization with: {
+			transferred selector.
+			category }].
 ]
 
 { #category : #initialization }

--- a/bootstrap/pharo/Powerlang-Core/RingBasedLMRBootstrapper.class.st
+++ b/bootstrap/pharo/Powerlang-Core/RingBasedLMRBootstrapper.class.st
@@ -230,7 +230,7 @@ RingBasedLMRBootstrapper >> createNewClassFrom: spec in: module [
 { #category : #initialization }
 RingBasedLMRBootstrapper >> createNewMethod: m in: species [
 
-	| smethod size transferred astcodes selector format tliteral md code |
+	| smethod size transferred astcodes selector format tliteral md organizer code category |
 	smethod := SCompiler new compile: m sourceCode.
 	smethod classBinding: species.
 	size := dest newInteger: smethod size.
@@ -256,6 +256,11 @@ RingBasedLMRBootstrapper >> createNewMethod: m in: species [
 	dest sendLocal: #at:put: to: md with: { 
 			selector.
 			transferred }.
+	organizer := dest sendLocal: #organization to: species.
+	category := dest addSymbol: m category.
+	dest sendLocal: #classify:under: to: organizer with: {
+			selector.
+			category }.
 	^ transferred
 ]
 


### PR DESCRIPTION
Some code depends on having categories properly loaded in order to perform its function. This change should fix that by classifying every method that is added to the LMR runtime. 