### PR TITLE
CompiledMethod: Add methods used by the nativization code

### DIFF
--- a/modules/Kernel/CompiledMethod.st
+++ b/modules/Kernel/CompiledMethod.st
@@ -243,6 +243,11 @@ CompiledMethod >> hasEnvironment [
 ]
 
 { #category : #accessing }
+CompiledMethod >> hasFrame [
+	^format isOnBit: HasFrame
+]
+
+{ #category : #accessing }
 CompiledMethod >> hasFrame: aBoolean [
 	format := aBoolean
 				ifTrue: [ format bitOr: HasFrame ]

--- a/modules/Kernel/CompiledMethod.st
+++ b/modules/Kernel/CompiledMethod.st
@@ -318,6 +318,11 @@ CompiledMethod >> isExtension [
 ]
 
 { #category : #testing }
+CompiledMethod >> isCalloutMethod [
+	^false
+]
+
+{ #category : #testing }
 CompiledMethod >> isFFIMethod [
 	^false
 ]

--- a/modules/Kernel/CompiledMethod.st
+++ b/modules/Kernel/CompiledMethod.st
@@ -323,6 +323,11 @@ CompiledMethod >> isCalloutMethod [
 ]
 
 { #category : #testing }
+CompiledMethod >> isFrameless [
+	^self hasFrame not
+]
+
+{ #category : #testing }
 CompiledMethod >> isFFIMethod [
 	^false
 ]


### PR DESCRIPTION
This PR adds `CompiledMethod >> hasFrame`, `CompiledMethod >> isCalloutMethod` and `CompiledMethod >> isFrameless`. These are all used by the `Nativization` module.