### PR TITLE
vm-st: Update Makefile to retry downloading pharo once

### DIFF
--- a/bootstrap/pharo/Makefile
+++ b/bootstrap/pharo/Makefile
@@ -19,7 +19,7 @@ endif
 all: pharo-ui bootstrap.image
 
 pharo pharo-ui Pharo.image:
-	curl https://get.pharo.org/64/90+vm | bash
+	curl https://get.pharo.org/64/90+vm | bash || curl https://get.pharo.org/64/90+vm | bash
 
 bootstrap.image: pharo Pharo.image
 	./pharo Pharo.image save bootstrap


### PR DESCRIPTION
As the get.pharo.org script fails randomly, make the makefile try once again if first time gave an error before failing the target