### PR TITLE
vm-st: rename missing things from JS packages

### DIFF
--- a/runtime/pharo/PowerlangJS-Core/JSTranspiler.class.st
+++ b/runtime/pharo/PowerlangJS-Core/JSTranspiler.class.st
@@ -60,7 +60,7 @@ JSTranspiler class >> generateMainSegments [
 JSTranspiler class >> generateMetacircularImage [
 
 	| image |
-	image := EggRingImage fromSpec
+	image := EggBootstrapImage fromSpec
 		         wordSize: 8;
 		         genesis;
 		         bootstrap;

--- a/runtime/pharo/PowerlangJS-Tests/EggJSModuleTest.class.st
+++ b/runtime/pharo/PowerlangJS-Tests/EggJSModuleTest.class.st
@@ -18,7 +18,7 @@ EggJSModuleTest >> setUp [
 
 	| image |
 	super setUp.
-	image := EggRingImage fromSpec
+	image := EggBootstrapImage fromSpec
 		         wordSize: 8;
 		         genesis;
 		         bootstrap;


### PR DESCRIPTION
To update to pharo12, replace ring with codespecs