### PR TITLE
vm-cpp: changes to build on MacOS

### DIFF
--- a/runtime/cpp/CMakeLists.txt
+++ b/runtime/cpp/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(FFI REQUIRED libffi)
 
 include_directories(${FFI_INCLUDE_DIRS})
+link_directories(${FFI_LIBRARY_DIRS})
+
 # *************************************************
 
 file(GLOB ALL_SRC "*.cpp" "Evaluator/*.cpp" "${PLATFORM}/*.cpp")

--- a/runtime/cpp/Posix/Memory.cpp
+++ b/runtime/cpp/Posix/Memory.cpp
@@ -30,7 +30,7 @@ uintptr_t Egg::ReserveMemory(uintptr_t base, uintptr_t size)
 
     while (true) {
         // Attempt to allocate at the aligned base
-        allocated = mmap(reinterpret_cast<void*>(base), pagealign(size), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+        allocated = mmap(reinterpret_cast<void*>(base), pagealign(size), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
         if (allocated != MAP_FAILED) {
             // Check if the allocated memory is at the desired base address
             if ((uintptr_t)allocated == base) {


### PR DESCRIPTION
Besides doing a `brew install libffi` these changes were required.
- Add libbffi to the linked directories
- Switch the MAP_FIXED_NOREPLACE to MAP_FIXED (noreplace was missing on MacOS), you may want to make this depending on the OS.

Trying to run a HelloWorld fails with `No Kernel.ems file`, but at it doesn't fail with memory errors anymore.