### PR TITLE
Jp/send local fix

### DIFF
--- a/modules/Kernel/ProtoObject.st
+++ b/modules/Kernel/ProtoObject.st
@@ -251,7 +251,7 @@ ProtoObject >> class [
 
 { #category : #system }
 ProtoObject >> doesNotUnderstand: aMessage [
-	^MessageNotUnderstood message: aMessage
+	^MessageNotUnderstood message: aMessage receiver: self
 ]
 
 { #category : #errors }

--- a/modules/Tonel/TonelModule.st
+++ b/modules/Tonel/TonelModule.st
@@ -9,6 +9,6 @@ TonelModule >> imports [
 	^{
 		#STON -> #(#STONReader #STONWriter #STON).
 		#Compiler -> #(#SSmalltalkParser).
-		#Kernel -> #(#OrderedDictionary #ReadStream)
+		#Kernel -> #(#Module #OrderedDictionary #ReadStream)
 	}
 ]

--- a/runtime/cpp/Evaluator/Evaluator.cpp
+++ b/runtime/cpp/Evaluator/Evaluator.cpp
@@ -318,7 +318,7 @@ void Egg::Evaluator::messageNotUnderstood_(SAbstractMessage *message)
 	auto array = _runtime->newArray_(args);
 	_context->push_(message->selector());
 	_context->push_((Object*)array);
-    auto symbol = _runtime->existingSymbolFrom_("_doesNotUnderstand:with:");
+    auto symbol = (Object*)_runtime->addSymbol_("_doesNotUnderstand:with:");
     auto behavior = _runtime->behaviorOf_(_regR);
 	auto dnu = _runtime->lookup_startingAt_((Object*)symbol, behavior);
     if (!dnu)

--- a/runtime/cpp/Evaluator/Evaluator.cpp
+++ b/runtime/cpp/Evaluator/Evaluator.cpp
@@ -69,6 +69,12 @@ void Evaluator::addPrimitive(const std::string &name, Evaluator::PrimitivePointe
 
 void Evaluator::addUndermessage(const std::string &name, UndermessagePointer primitive) {
     Object *symbol = _runtime->existingSymbolFrom_(name);
+    if (!symbol) {
+        // Symbol does not (yet) exist in the kernel symbol table; skip registration
+        // to avoid storing the undermessage under a nullptr key, which would later
+        // be matched by any send whose selector cannot be resolved.
+        return;
+    }
     _undermessages[symbol] = primitive;
 }
 

--- a/runtime/cpp/Evaluator/Runtime.cpp
+++ b/runtime/cpp/Evaluator/Runtime.cpp
@@ -209,12 +209,12 @@ uintptr_t Runtime::hashFor_(Object *anObject)
  }
 
 Object* Runtime::sendLocal_to_withArgs_(const std::string &selector, Object *receiver, std::vector<Object*> &arguments) {
-    auto symbol = this->existingSymbolFrom_(selector);
+    auto symbol = (Object*)this->addSymbol_(selector);
     return this->_evaluator->send_to_with_(symbol, receiver, arguments);
 }
 
 Object* Runtime::sendLocal_to_with_(const std::string &selector, Object *receiver, Object* arg1) {
-    auto symbol = this->existingSymbolFrom_(selector);
+    auto symbol = (Object*)this->addSymbol_(selector);
     std::vector<Object*> args;
     args.push_back(arg1);
 
@@ -222,7 +222,7 @@ Object* Runtime::sendLocal_to_with_(const std::string &selector, Object *receive
 }
 
 Object* Runtime::sendLocal_to_with_with_(const std::string &selector, Object *receiver, Object *arg1, Object* arg2) {
-    auto symbol = this->existingSymbolFrom_(selector);
+    auto symbol = (Object*)this->addSymbol_(selector);
     std::vector<Object*> args;
     args.push_back(arg1);
     args.push_back(arg2);

--- a/runtime/cpp/Main.cpp
+++ b/runtime/cpp/Main.cpp
@@ -6,8 +6,19 @@
 
 #include "Launcher.h"
 
+#include <exception>
+#include <iostream>
+
 int
 main(const int argc, const char** argv) {
-	Egg::Launcher launcher;
-	return launcher.main(argc, argv);
+    Egg::Launcher launcher;
+    try {
+        return launcher.main(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    } catch (...) {
+        std::cerr << "Error: unknown exception reached top level" << std::endl;
+        return 1;
+    }
 }


### PR DESCRIPTION
fix for a hard vm crash when the module loaded by egg does not have a main:. It should just fail with a dnu, but in sending #main: the vm was assuming the #main: symbol always existed and corrupt the state. This PR fixes it (for any sendLocal*)